### PR TITLE
[fix] Change bluedart testing and production urls to version 1.8

### DIFF
--- a/bluedart/services/pickup_service.py
+++ b/bluedart/services/pickup_service.py
@@ -14,9 +14,10 @@ class BlueDartPickupRequest(BlueDartBaseService):
 
         self.profile_obj = profile_obj
 
-        wsdl_url = "http://netconnect.bluedart.com/Ver1.7/ShippingAPI/Pickup/PickupRegistrationService.svc?wsdl"
+        wsdl_url = "http://netconnect.bluedart.com/Ver1.8/ShippingAPI/Pickup/PickupRegistrationService.svc?wsdl"
         if self.profile_obj.use_test_server:
-            wsdl_url = "http://netconnect.bluedart.com/Demo/ShippingAPI/Pickup/PickupRegistrationService.svc?wsdl"
+            wsdl_url = "http://netconnect.bluedart.com/Ver1.8/Demo/ShippingAPI/Pickup/PickupRegistrationService.svc?" \
+                       "wsdl"
 
         self.request = None
         self.profile = None

--- a/bluedart/services/ship_service.py
+++ b/bluedart/services/ship_service.py
@@ -14,9 +14,9 @@ class BlueDartProcessShipmentRequest(BlueDartBaseService):
 
         self.profile_obj = profile_obj
 
-        wsdl_url = "http://netconnect.bluedart.com/Ver1.7/ShippingAPI/WayBill/WayBillGeneration.svc?wsdl"
+        wsdl_url = "http://netconnect.bluedart.com/Ver1.8/ShippingAPI/WayBill/WayBillGeneration.svc?wsdl"
         if self.profile_obj.use_test_server:
-            wsdl_url = "http://netconnect.bluedart.com/Demo/ShippingAPI/Waybill/WayBillGeneration.svc?wsdl"
+            wsdl_url = "http://netconnect.bluedart.com/Ver1.8/Demo/ShippingAPI/Waybill/WayBillGeneration.svc?wsdl"
 
         self.Request = None
         self.Profile = None
@@ -49,8 +49,8 @@ class BlueDartProcessShipmentRequest(BlueDartBaseService):
     def _assemble_and_send_request(self):
         """
         Fires off the Bluedart request.
-        
-        @warning: NEVER CALL THIS METHOD DIRECTLY. CALL send_request(), 
+
+        @warning: NEVER CALL THIS METHOD DIRECTLY. CALL send_request(),
             WHICH RESIDES ON FedexBaseService AND IS INHERITED.
         """
 
@@ -67,9 +67,9 @@ class BlueDartCancelShipmentRequest(BlueDartBaseService):
 
         self.profile_obj = profile_obj
 
-        wsdl_url = "http://netconnect.bluedart.com/Ver1.7/ShippingAPI/WayBill/WayBillGeneration.svc?wsdl"
+        wsdl_url = "http://netconnect.bluedart.com/Ver1.8/ShippingAPI/WayBill/WayBillGeneration.svc?wsdl"
         if self.profile_obj.use_test_server:
-            wsdl_url = "http://netconnect.bluedart.com/Demo/ShippingAPI/Waybill/WayBillGeneration.svc?wsdl"
+            wsdl_url = "http://netconnect.bluedart.com/Ver1.8/Demo/ShippingAPI/Waybill/WayBillGeneration.svc?wsdl"
 
         self.Request = None
         self.Profile = None


### PR DESCRIPTION
Previous testing url has been not working for bluedart and they provide new testing and production urls of version 1.8.